### PR TITLE
default sendMailToParent

### DIFF
--- a/DOL.WHD.Section14c.Business/Services/ApplicationService.cs
+++ b/DOL.WHD.Section14c.Business/Services/ApplicationService.cs
@@ -70,6 +70,19 @@ namespace DOL.WHD.Section14c.Business.Services
             model.CertificateEffectiveDate = null;
             model.CertificateExpirationDate = null;
             model.CertificateNumber = null;
+
+            // default checkboxes
+            if (model.Employer != null)
+            {
+                if (model.Employer.HasParentOrg.GetValueOrDefault())
+                {
+                    model.Employer.SendMailToParent = model.Employer.SendMailToParent ?? false;
+                }
+                else
+                {
+                    model.Employer.SendMailToParent = null;
+                }
+            }
         }
 
         private void CleanupWageTypeInfo(WageTypeInfo wageTypeInfo)

--- a/DOL.WHD.Section14c.Test/Business/ApplicationServiceTests.cs
+++ b/DOL.WHD.Section14c.Test/Business/ApplicationServiceTests.cs
@@ -224,5 +224,44 @@ namespace DOL.WHD.Section14c.Test.Business
             Assert.IsNull(obj.CertificateExpirationDate);
             Assert.IsNull(obj.CertificateNumber);
         }
+
+        [TestMethod]
+        public void ApplicationService_Defaults_SendMailToParent_Null()
+        {
+            // Arrange
+            var obj = new ApplicationSubmission {Employer = new EmployerInfo {HasParentOrg = true}};
+
+            // Act
+            _applicationService.ProcessModel(obj);
+
+            // Assert
+            Assert.IsFalse(obj.Employer.SendMailToParent.Value);
+        }
+
+        [TestMethod]
+        public void ApplicationService_Defaults_SendMailToParent_NotNull()
+        {
+            // Arrange
+            var obj = new ApplicationSubmission { Employer = new EmployerInfo { HasParentOrg = true, SendMailToParent = true} };
+
+            // Act
+            _applicationService.ProcessModel(obj);
+
+            // Assert
+            Assert.IsTrue(obj.Employer.SendMailToParent.Value);
+        }
+
+        [TestMethod]
+        public void ApplicationService_Cleans_SendMailToParent()
+        {
+            // Arrange
+            var obj = new ApplicationSubmission { Employer = new EmployerInfo { SendMailToParent = true } };
+
+            // Act
+            _applicationService.ProcessModel(obj);
+
+            // Assert
+            Assert.IsNull(obj.Employer.SendMailToParent);
+        }
     }
 }


### PR DESCRIPTION
Default sendMailToParent in case the client doesn't specify a value. This
will be false, but sometimes angular doesn't set the checkbox value
properly.